### PR TITLE
支持多种不同样式得待办事项标记

### DIFF
--- a/src/component/calendar/func/todo.js
+++ b/src/component/calendar/func/todo.js
@@ -61,6 +61,7 @@ class Todo extends WxData {
       if (target.showTodoLabel && todo.todoText) {
         target.todoText = todo.todoText;
       }
+      if (todo.todoLabelColor) target.todoLabelColor = todo.todoLabelColor
     }
     const o = {
       'calendar.days': dates,

--- a/src/component/calendar/index.wxml
+++ b/src/component/calendar/index.wxml
@@ -56,7 +56,7 @@
                 <view
                   wx:if="{{item.showTodoLabel && !calendar.todoLabelCircle}}"
                   class="{{item.todoText ? 'date-desc' : calendarConfig.theme + '_todo-dot todo-dot'}} {{calendarConfig.showLunar ? calendarConfig.theme + '_date-desc-lunar' : ''}} {{calendar.todoLabelPos === 'bottom' ? 'date-desc-bottom todo-dot-bottom' : 'date-desc-top todo-dot-top'}} {{calendar.showLabelAlways && item.choosed && calendar.todoLabelPos === 'bottom' ? 'date-desc-bottom-always todo-dot-bottom-always' : ''}} {{calendar.showLabelAlways && item.choosed && calendar.todoLabelPos === 'top' ? 'date-desc-top-always todo-dot-top-always' : ''}}"
-                  style="background-color: {{calendar.todoLabelColor}};">
+                  style="background-color: {{item.todoLabelColor || calendar.todoLabelColor}};"> 
                     {{item.todoText}}
                 </view>
               </view>


### PR DESCRIPTION
只需要在设置待办事项时添加字段todoLabelColor就可以设置任意不同颜色得标记
`this.calendar.setTodoLabels({ ... days: [{ year, month, day, todoLabelColor: 'red', },{ year, month, day, todoLabelColor: 'blue', }] })`