### PR TITLE
fix: 设置日历配置显示农历不生效

### DIFF
--- a/src/component/calendar/func/day.js
+++ b/src/component/calendar/func/day.js
@@ -32,7 +32,6 @@ class Day extends WxData {
     const today = getDate.todayDate();
     const thisMonthDays = getDate.thisMonthDays(year, month);
     const dates = [];
-    const { showLunar } = this.getCalendarConfig();
     for (let i = 1; i <= thisMonthDays; i++) {
       const isToday =
         +today.year === +year && +today.month === +month && i === +today.date;
@@ -43,15 +42,9 @@ class Day extends WxData {
         day: i,
         choosed: false,
         week: getDate.dayOfWeek(year, month, i),
-        isToday: isToday && config.highlightToday
+        isToday: isToday && config.highlightToday,
+        lunar: convertSolarLunar.solar2lunar(+year, +month, +i)
       };
-      if (showLunar) {
-        date.lunar = convertSolarLunar.solar2lunar(
-          +date.year,
-          +date.month,
-          +date.day
-        );
-      }
       dates.push(date);
     }
     return dates;


### PR DESCRIPTION
初始化日历时配置：

```js
const conf = {
  data: {
    calendarConfig: {
      showLunar: false
    }
  }
};

Page(conf);
```

使用 `setCalendarConfig ` 设置显示农历：

```js
this.calendar.setCalendarConfig({
  showLunar: true
});
```

结果：显示农历不生效