### PR TITLE
bug fixed

### DIFF
--- a/src/component/v2/plugins/selectable.js
+++ b/src/component/v2/plugins/selectable.js
@@ -119,8 +119,6 @@ export default () => {
           if (disableDates && disableDates.length) {
             if (disableDates && disableDates.includes(timeStr)) {
               item.disable = true
-            } else {
-              item.disable = false
             }
             return item
           }


### PR DESCRIPTION
先配置了disableMode: {
        type: 'before'
}
再调用 calendar.disableDates(['2021-7-12', '2021-7-13', '2021-7-14'])方法
 
后面的方法会导致配置的禁用日期失效。